### PR TITLE
Define required iterator scope in "for of"

### DIFF
--- a/test/12-forof-intro.js
+++ b/test/12-forof-intro.js
@@ -82,7 +82,7 @@ test.skip('Objects can be iterated using helpers', t => {
   let obj = {x: 'Foo', y: 'Bar', z: 'Baz' };
 
   let ks = [];
-  for (k of __) { // <-- Fill in the blank
+  for (let k of __) { // <-- Fill in the blank
     ks.push(k);
   }
 


### PR DESCRIPTION
Test "Objects can be iterated using helpers" fails when the iterator scope is not explicitly set.
